### PR TITLE
"Columbia" restriction, fixed cucumber & spec test

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    @user = User.new(params.require(:user).permit(:username, :password))
+    @user = User.new(params.require(:user).permit(:username, :email, :password))
     if @user.save
       flash[:notice] = "Registration successful! Please log in"
       redirect_to new_session_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
     validates :username, uniqueness: { message: "Username already exists" }
     validates :password, presence: { message: "Password can not be blank" }
     validates :password, length: { minimum: 6, message: "The minimum password length is 6 characters" }
+    validates :email, format: { with: /\A[\w+\-.]+@columbia\.edu\z/i, message: "must be a Columbia University email" }
 
     has_many :blogs
     has_many :public_blogs, -> { where(is_public: true) },

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,6 +22,10 @@
       </div>
 
       <div class="mb-3">
+        <%= f.email_field :email, class: "form-control", placeholder: "Email" %>
+      </div>
+
+      <div class="mb-3">
         <%= f.password_field :password, class: "form-control", placeholder: "Password" %>
       </div>
 

--- a/db/migrate/20231216091753_add_email_to_users.rb
+++ b/db/migrate/20231216091753_add_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_10_204913) do
     t.string "password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email"
   end
 
 end

--- a/features/send_and_receive_message.feature
+++ b/features/send_and_receive_message.feature
@@ -9,7 +9,7 @@ Scenario: Successful send message
     When I enter my valid username and password
     And I press "Login"
     And I should see a welcome message
-    And I click on "Messages"
+    And I click on "Messages" in the "portal"
     And I should see a list of inbox messages
     When I click on "Create Message"
     Then I am redirected to the send message page
@@ -25,7 +25,7 @@ Scenario: Unsuccessful send message with error received
     When I enter my valid username and password
     And I press "Login"
     And I should see a welcome message
-    And I click on "Messages"
+    And I click on "Messages" in the "navbar"
     And I should see a list of inbox messages
     When I click on "Create Message"
     Then I am redirected to the send message page
@@ -39,7 +39,7 @@ Scenario: Unsuccessful send message with missing fields
     When I enter my valid username and password
     And I press "Login"
     And I should see a welcome message
-    And I click on "Messages"
+    And I click on "Messages" in the "navbar"
     And I should see a list of inbox messages
     When I click on "Create Message"
     Then I am redirected to the send message page
@@ -54,7 +54,7 @@ Scenario: Receive message
     When I enter my valid username and password
     And I press "Login"
     And I should see a welcome message
-    And I click on "Messages"
+    And I click on "Messages" in the "navbar"
     And I should see a list of inbox messages
     When I click on "Inbox"
     And I should see a list of inbox messages containing received messages

--- a/features/sign_up.feature
+++ b/features/sign_up.feature
@@ -14,3 +14,9 @@ Scenario: Unsuccessful signup with missing fields
     When I fill in only username
     And I press "Registration"
     Then I am on page register
+
+Scenario: Unsuccessful signup with non-Columbia email
+    Given I am on register page
+    When I fill in username, non-Columbia email, and password
+    And I press "Registration"
+    Then I should see an error message about Columbia email

--- a/features/step_definitions/blogs.rb
+++ b/features/step_definitions/blogs.rb
@@ -1,7 +1,7 @@
 # features/step_definitions/blog_steps.rb
 
 Given("I am a registered user for Blog") do
-  @user = User.create!(username: "test@example.com", password: "password")
+  @user = User.create!(username: "testuser", email: "test@columbia.edu", password: "password")
 
   visit '/sessions/new'
 

--- a/features/step_definitions/send_and_receive_message_steps.rb
+++ b/features/step_definitions/send_and_receive_message_steps.rb
@@ -1,6 +1,6 @@
 Given('two registered user') do
-  @user1 = User.create!(username: 'weiran', password: '123456')
-  @user2 = User.create!(username: 'weiran2', password: '123456')
+  @user1 = User.create!(username: 'weiran', email: "weiran@columbia.edu", password: '123456')
+  @user2 = User.create!(username: 'weiran2', email: "weiran2@columbia.edu", password: '123456')
 end
 
 Then('I fill in the message fields') do

--- a/features/step_definitions/sign_up.steps.rb
+++ b/features/step_definitions/sign_up.steps.rb
@@ -4,7 +4,18 @@ end
 
 When('I fill in username and password') do
   fill_in 'user[username]', with: 'weiran'
+  fill_in 'user[email]', with: 'weiran@columbia.edu' 
   fill_in 'user[password]', with: '123456'
+end
+
+When('I fill in username, non-Columbia email, and password') do
+  fill_in 'user[username]', with: 'weiran'
+  fill_in 'user[email]', with: 'weiran@example.com' # Non-Columbia email
+  fill_in 'user[password]', with: '123456'
+end
+
+Then('I should see an error message about Columbia email') do
+  expect(page).to have_content('Email must be a Columbia University email')
 end
 
 When('I should redirected to the login page') do

--- a/features/step_definitions/visit_message_steps.rb
+++ b/features/step_definitions/visit_message_steps.rb
@@ -1,5 +1,5 @@
 Given('a registered user') do
-  @user = User.create!(username: 'weiran', password: '123456')
+  @user = User.create!(username: 'weiran', email: "weiran@columbia.edu", password: '123456')
 end
 
 Given('I am on the home page') do
@@ -8,6 +8,23 @@ end
 
 Given('I click on {string}') do |string|
   click_on string
+end
+
+And /^(?:|I )click on "([^"]*)" in the "([^"]*)"$/ do |link_or_button, location|
+  within(location_selector(location)) do
+    click_on(link_or_button)
+  end
+end
+
+def location_selector(location)
+  case location
+  when 'navbar'
+    'nav' 
+  when 'portal'
+    '.portal'
+  else
+    raise "Unknown location: #{location}"
+  end
 end
 
 Then('I am redirected to the login page') do

--- a/features/visit_message.feature
+++ b/features/visit_message.feature
@@ -4,7 +4,7 @@ Feature: Visit Messages
 
 Scenario: Not logged in
     Given I am on the home page
-    And I click on "Messages"
+    And I click on "Messages" in the "portal"
     Then I am redirected to the login page
 
 Scenario: Successful login and enter message page
@@ -13,7 +13,7 @@ Scenario: Successful login and enter message page
     When I enter my valid username and password
     And I press "Login"
     And I should see a welcome message
-    And I click on "Messages"
+    And I click on "Messages" in the "navbar"
     And I should see a list of inbox messages
     When I click on "Outbox"
     And I should see a list of outbox messages

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "valid_user_#{n}_#{Time.now.to_i}" }
+    email { "testuser@columbia.edu" }
     password { 'secure_password' }
   end
 

--- a/spec/users_controller_spec.rb
+++ b/spec/users_controller_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe UsersController, type: :controller do
     context 'with valid parameters' do
       it 'creates a new user' do
         expect do
-          post :create, params: { user: { username: 'newuser', password: 'password' } }
+          post :create, params: { user: { username: 'newuser', email: 'newuser@columbia.edu', password: 'password' } }
         end.to change(User, :count).by(1)
       end
 
       it 'redirects to the login page' do
-        post :create, params: { user: { username: 'newuser', password: 'password' } }
+        post :create, params: { user: { username: 'newuser', email: 'newuser@columbia.edu', password: 'password' } }
         expect(response).to redirect_to(new_session_path)
       end
     end
     context 'with invalid parameters' do
       it 'does not create a new user' do
         expect do
-          post :create, params: { user: { username: '', password: '' } }
+          post :create, params: { user: { username: '', email: '', password: '' } }
         end.not_to change(User, :count)
       end
 
       it 're-renders the new template' do
-        post :create, params: { user: { username: '', password: '' } }
+        post :create, params: { user: { username: '', email: '', password: '' } }
         expect(response).to render_template(:new)
       end
     end
@@ -42,12 +42,12 @@ RSpec.describe UsersController, type: :controller do
     context 'with invalid attributes' do
       it 'does not save the user' do
         expect {
-          post :create, params: { user: { username: nil, password: nil } }
+          post :create, params: { user: { username: nil, email: nil, password: nil } }
         }.to_not change(User, :count)
       end
       
       it 're-renders the new template' do
-        post :create, params: { user: { username: nil, password: nil } }
+        post :create, params: { user: { username: nil, email: nil, password: nil } }
         expect(response).to render_template(:new)
       end
     end


### PR DESCRIPTION
At registration, a "columbia.edu" ending email is required to make sure that the person registering is a Columbia University student. And fixed cucumber tests and spec tests accordingly.